### PR TITLE
Couple updates for EuiConfirmModal PR

### DIFF
--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -1151,7 +1151,10 @@ const typeDefinitionExtractors = {
    */
   VariableDeclaration: node => {
     return node.declarations.reduce((declarations, declaration) => {
-      if (declaration.init.type === 'ObjectExpression') {
+      if (
+        declaration.init != null &&
+        declaration.init.type === 'ObjectExpression'
+      ) {
         declarations.push({
           name: declaration.id.name,
           definition: declaration.init,

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -2613,6 +2613,18 @@ FooComponent.propTypes = {
       });
     });
 
+    describe('misc', () => {
+      it('supports non-initialized variable declarations', () => {
+        const result = transform(
+          `
+let something: any;
+`,
+          babelOptions
+        );
+
+        expect(result.code).toBe('let something;');
+      });
+    });
   });
 
   describe('remove types from exports', () => {

--- a/src/components/modal/confirm_modal.test.tsx
+++ b/src/components/modal/confirm_modal.test.tsx
@@ -10,151 +10,153 @@ import {
   EuiConfirmModal,
 } from './confirm_modal';
 
-let onConfirm: any;
-let onCancel: any;
+let onConfirm: jest.Mock;
+let onCancel: jest.Mock;
 
 beforeEach(() => {
   onConfirm = jest.fn();
   onCancel = jest.fn();
 });
 
-test('renders EuiConfirmModal', () => {
-  const component = render(
-    <EuiConfirmModal
-      title="A confirmation modal"
-      onCancel={() => {}}
-      onConfirm={onConfirm}
-      cancelButtonText="Cancel Button Text"
-      confirmButtonText="Confirm Button Text"
-      {...requiredProps}>
-      This is a confirmation modal example
-    </EuiConfirmModal>
-  );
-  expect(component).toMatchSnapshot();
-});
-
-test('renders EuiConfirmModal without EuiModalBody, if empty', () => {
-  const component = render(
-    <EuiConfirmModal
-      title="A confirmation modal"
-      onCancel={() => {}}
-      onConfirm={onConfirm}
-      cancelButtonText="Cancel Button Text"
-      confirmButtonText="Confirm Button Text"
-      {...requiredProps}
-    />
-  );
-  expect(component).toMatchSnapshot();
-});
-
-test('onConfirm', () => {
-  const component = mount(
-    <EuiConfirmModal
-      onCancel={onCancel}
-      onConfirm={onConfirm}
-      cancelButtonText="Cancel Button Text"
-      confirmButtonText="Confirm Button Text"
-    />
-  );
-
-  findTestSubject(component, 'confirmModalConfirmButton').simulate('click');
-  expect(onConfirm).toHaveBeenCalledTimes(1);
-  expect(onCancel).toHaveBeenCalledTimes(0);
-});
-
-test('onConfirm can be disabled', () => {
-  const component = mount(
-    <EuiConfirmModal
-      onCancel={onCancel}
-      onConfirm={onConfirm}
-      cancelButtonText="Cancel Button Text"
-      confirmButtonText="Confirm Button Text"
-      confirmButtonDisabled={true}
-    />
-  );
-
-  findTestSubject(component, 'confirmModalConfirmButton').simulate('click');
-  expect(onConfirm).toHaveBeenCalledTimes(0);
-  expect(onCancel).toHaveBeenCalledTimes(0);
-});
-
-describe('onCancel', () => {
-  test('triggerd by click', () => {
-    const component = mount(
+describe('EuiConfirmModal', () => {
+  test('renders EuiConfirmModal', () => {
+    const component = render(
       <EuiConfirmModal
-        onCancel={onCancel}
+        title="A confirmation modal"
+        onCancel={() => {}}
         onConfirm={onConfirm}
         cancelButtonText="Cancel Button Text"
         confirmButtonText="Confirm Button Text"
-      />
+        {...requiredProps}>
+        This is a confirmation modal example
+      </EuiConfirmModal>
     );
-
-    findTestSubject(component, 'confirmModalCancelButton').simulate('click');
-    expect(onConfirm).toHaveBeenCalledTimes(0);
-    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(component).toMatchSnapshot();
   });
 
-  test('triggered by esc key', () => {
+  test('renders EuiConfirmModal without EuiModalBody, if empty', () => {
+    const component = render(
+      <EuiConfirmModal
+        title="A confirmation modal"
+        onCancel={() => {}}
+        onConfirm={onConfirm}
+        cancelButtonText="Cancel Button Text"
+        confirmButtonText="Confirm Button Text"
+        {...requiredProps}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  test('onConfirm', () => {
     const component = mount(
       <EuiConfirmModal
         onCancel={onCancel}
         onConfirm={onConfirm}
         cancelButtonText="Cancel Button Text"
         confirmButtonText="Confirm Button Text"
-        data-test-subj="modal"
       />
     );
 
-    findTestSubject(component, 'modal').simulate('keydown', {
-      keyCode: keyCodes.ESCAPE,
+    findTestSubject(component, 'confirmModalConfirmButton').simulate('click');
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(0);
+  });
+
+  test('onConfirm can be disabled', () => {
+    const component = mount(
+      <EuiConfirmModal
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        cancelButtonText="Cancel Button Text"
+        confirmButtonText="Confirm Button Text"
+        confirmButtonDisabled={true}
+      />
+    );
+
+    findTestSubject(component, 'confirmModalConfirmButton').simulate('click');
+    expect(onConfirm).toHaveBeenCalledTimes(0);
+    expect(onCancel).toHaveBeenCalledTimes(0);
+  });
+
+  describe('onCancel', () => {
+    test('triggerd by click', () => {
+      const component = mount(
+        <EuiConfirmModal
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+          cancelButtonText="Cancel Button Text"
+          confirmButtonText="Confirm Button Text"
+        />
+      );
+
+      findTestSubject(component, 'confirmModalCancelButton').simulate('click');
+      expect(onConfirm).toHaveBeenCalledTimes(0);
+      expect(onCancel).toHaveBeenCalledTimes(1);
     });
-    expect(onConfirm).toHaveBeenCalledTimes(0);
-    expect(onCancel).toHaveBeenCalledTimes(1);
-  });
-});
 
-describe('defaultFocusedButton', () => {
-  test('is cancel', done => {
-    const component = mount(
-      <EuiConfirmModal
-        onCancel={onCancel}
-        onConfirm={onConfirm}
-        cancelButtonText="Cancel Button Text"
-        confirmButtonText="Confirm Button Text"
-        defaultFocusedButton={CANCEL_BUTTON}
-      />
-    );
+    test('triggered by esc key', () => {
+      const component = mount(
+        <EuiConfirmModal
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+          cancelButtonText="Cancel Button Text"
+          confirmButtonText="Confirm Button Text"
+          data-test-subj="modal"
+        />
+      );
 
-    // The auto-focus implementation waits a frame before focusing.
-    requestAnimationFrame(() => {
-      const button = findTestSubject(
-        component,
-        'confirmModalCancelButton'
-      ).getDOMNode();
-      expect(document.activeElement).toEqual(button);
-      done();
+      findTestSubject(component, 'modal').simulate('keydown', {
+        keyCode: keyCodes.ESCAPE,
+      });
+      expect(onConfirm).toHaveBeenCalledTimes(0);
+      expect(onCancel).toHaveBeenCalledTimes(1);
     });
   });
 
-  test('is confirm', done => {
-    const component = mount(
-      <EuiConfirmModal
-        onCancel={onCancel}
-        onConfirm={onConfirm}
-        cancelButtonText="Cancel Button Text"
-        confirmButtonText="Confirm Button Text"
-        defaultFocusedButton={CONFIRM_BUTTON}
-      />
-    );
+  describe('defaultFocusedButton', () => {
+    test('is cancel', done => {
+      const component = mount(
+        <EuiConfirmModal
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+          cancelButtonText="Cancel Button Text"
+          confirmButtonText="Confirm Button Text"
+          defaultFocusedButton={CANCEL_BUTTON}
+        />
+      );
 
-    // The auto-focus implementation waits a frame before focusing.
-    requestAnimationFrame(() => {
-      const button = findTestSubject(
-        component,
-        'confirmModalConfirmButton'
-      ).getDOMNode();
-      expect(document.activeElement).toEqual(button);
-      done();
+      // The auto-focus implementation waits a frame before focusing.
+      requestAnimationFrame(() => {
+        const button = findTestSubject(
+          component,
+          'confirmModalCancelButton'
+        ).getDOMNode();
+        expect(document.activeElement).toEqual(button);
+        done();
+      });
+    });
+
+    test('is confirm', done => {
+      const component = mount(
+        <EuiConfirmModal
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+          cancelButtonText="Cancel Button Text"
+          confirmButtonText="Confirm Button Text"
+          defaultFocusedButton={CONFIRM_BUTTON}
+        />
+      );
+
+      // The auto-focus implementation waits a frame before focusing.
+      requestAnimationFrame(() => {
+        const button = findTestSubject(
+          component,
+          'confirmModalConfirmButton'
+        ).getDOMNode();
+        expect(document.activeElement).toEqual(button);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
Created test and fix for empty variable declarations in ts->proptypes babel plugin; wrapped EuiConfirmModal tests in a describe block; changed two any types to jest.Mock